### PR TITLE
Fix off-by-one random generation typo

### DIFF
--- a/leancloud/file_.py
+++ b/leancloud/file_.py
@@ -133,7 +133,7 @@ class File(object):
             base64.encode(self._source, output)
             self._source.seek(0)
             output.seek(0)
-            hex_octet = lambda: hex(int(1 + random.random() * 0x10000))[2:]
+            hex_octet = lambda: hex(int(1 + random.random()) * 0x10000)[2:]
             key = ''.join(hex_octet() for _ in xrange(4))
             key = '{0}.{1}'.format(key, self.extension)
             data = {


### PR DESCRIPTION
修复 hex-octet 生成随机数过程中的括号错位问题。参考 javascript-sdk: 

https://github.com/leancloud/javascript-sdk/blob/b61f967f53c3b88d3ef635712b67abdd6a70d521/lib/file.js#L519