### PR TITLE
add leancloud.use_master_key API

### DIFF
--- a/leancloud/__init__.py
+++ b/leancloud/__init__.py
@@ -3,11 +3,17 @@
 """LeanCloud Python SDK
 """
 
+import logging
+
+logger = logging.getLogger('iso8601.iso8601')
+logger.setLevel(logging.CRITICAL)
+
 import client
 import push
 from .push import Installation
 from .acl import ACL
 from .client import init
+from .client import use_master_key
 from .client import use_production
 from .errors import LeanCloudError
 from .file_ import File
@@ -30,22 +36,23 @@ __version__ = '1.3.5'
 
 __all__ = [
     'ACL',
+    'Engine',
     'File',
-    'HttpsRedirectMiddleware',
     'FriendshipQuery',
     'GeoPoint',
+    'HttpsRedirectMiddleware',
+    'Installation',
     'LeanCloudError',
     'LeanEngineError',
     'Object',
     'Query',
     'Relation',
+    'Role',
     'User',
     'client',
-    'use_production',
+    'cloudfunc',
     'init',
     'push',
-    'cloudfunc',
-    'Role',
-    'Installation',
-    'Engine',
+    'use_master_key',
+    'use_production',
 ]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,14 +14,20 @@ except KeyError:
 else:
     import leancloud.client
     leancloud.client.TIMEOUT_SECONDS = 60
+
+
 try:
     os.environ['APP_KEY']
 except KeyError:
     os.environ['APP_KEY'] = 'hi4jsm62kok2qz2w2qphzryo564rzsrucl2czb0hn6ogwwnd'
+
+
 try:
     os.environ['MASTER_KEY']
 except KeyError:
     os.environ['MASTER_KEY'] = 'azkuvukzlq3t38abdrgrwqqdcx9me6178ctulhd14wynfq1n'
+
+
 try:
     leancloud.client.IMEOUT_SECONDS = int(os.environ['TRAVIS_TIMEOUT'])
 except KeyError:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+
+import os
 import datetime
 
 import leancloud
@@ -14,6 +16,15 @@ def test_use_production():
     assert client.USE_PRODUCTION == 0
     leancloud.use_production(True)
     assert client.USE_PRODUCTION == 1
+
+
+def test_use_master_key():
+    leancloud.init(os.environ['APP_ID'], os.environ['APP_KEY'], os.environ['MASTER_KEY'])
+    assert client.USE_MASTER_KEY is None
+    leancloud.use_master_key(True)
+    assert client.USE_MASTER_KEY is True
+    leancloud.use_master_key(False)
+    assert client.USE_MASTER_KEY is False
 
 
 def test_get_server_time():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -50,6 +50,10 @@ HookObject = leancloud.Object.extend('HookObject')
 
 
 def setup():
+    leancloud.client.USE_MASTER_KEY = None
+    leancloud.client.APP_ID = None
+    leancloud.client.APP_KEY = None
+    leancloud.client.MASTER_KEY = None
     leancloud.init(TEST_APP_ID, TEST_APP_KEY)
     authorization._ENABLE_TEST = True
     authorization.APP_ID = TEST_APP_ID

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -15,6 +15,10 @@ __author__ = 'asaka <lan@leancloud.rocks>'
 
 
 def setup_func():
+    leancloud.client.USE_MASTER_KEY = None
+    leancloud.client.APP_ID = None
+    leancloud.client.APP_KEY = None
+    leancloud.client.MASTER_KEY = None
     leancloud.init(
         os.environ['APP_ID'],
         os.environ['APP_KEY']

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -36,6 +36,10 @@ B = Object.extend('B')
 
 
 def setup_func():
+    leancloud.client.USE_MASTER_KEY = None
+    leancloud.client.APP_ID = None
+    leancloud.client.APP_KEY = None
+    leancloud.client.MASTER_KEY = None
     leancloud.init(
         os.environ['APP_ID'],
         os.environ['APP_KEY']

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -14,6 +14,10 @@ __author__ = 'asaka <lan@leancloud.rocks>'
 
 
 def only_init():
+    leancloud.client.USE_MASTER_KEY = None
+    leancloud.client.APP_ID = None
+    leancloud.client.APP_KEY = None
+    leancloud.client.MASTER_KEY = None
     leancloud.init(
         os.environ['APP_ID'],
         master_key=os.environ['MASTER_KEY']
@@ -21,6 +25,10 @@ def only_init():
 
 
 def setup_func():
+    leancloud.client.USE_MASTER_KEY = None
+    leancloud.client.APP_ID = None
+    leancloud.client.APP_KEY = None
+    leancloud.client.MASTER_KEY = None
     leancloud.init(
         os.environ['APP_ID'],
         master_key=os.environ['MASTER_KEY']
@@ -222,7 +230,11 @@ def test_get_methods():
 
 @with_setup(setup_func)
 def test_request_password_reset():
-    User.request_password_reset('wow@leancloud.rocks')
+    try:
+        User.request_password_reset('wow@leancloud.rocks')
+    except LeanCloudError as e:
+        if u'请不要往同一个邮件地址发送太多邮件。' not in e.message:
+            raise e
 
 
 @with_setup(setup_func)


### PR DESCRIPTION
增加了是否适用 master key 的选项。之前的 API，是根据 `leancloud.init` 的时候使用的 app key 还是 master key 来决定的。现在可以通过 API 来控制了。

新的 API 如果不调用，应该和以前的行为相同。