### PR TITLE
bugfix in User#logout

### DIFF
--- a/leancloud/user.py
+++ b/leancloud/user.py
@@ -97,9 +97,9 @@ class User(Object):
         self._server_data.pop('password', None)
         self._rebuild_estimated_data_for_key('password')
 
-    def save(self):
+    def save(self, make_current=False):
         super(User, self).save()
-        self._handle_save_result(False)
+        self._handle_save_result(make_current)
 
     def sign_up(self, username=None, password=None):
         """
@@ -118,7 +118,7 @@ class User(Object):
         if not password:
             raise TypeError('invalid password')
 
-        self.save()
+        self.save(make_current=True)
 
     def login(self, username=None, password=None):
         """
@@ -139,7 +139,6 @@ class User(Object):
     def logout(self):
         if not self.is_current:
             return
-        self._logout_with_all()
         self._cleanup_auth_data()
         thread_locals.current_user = None
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -233,7 +233,7 @@ def test_request_password_reset():
     try:
         User.request_password_reset('wow@leancloud.rocks')
     except LeanCloudError as e:
-        if u'请不要往同一个邮件地址发送太多邮件。' not in e.message:
+        if u'请不要往同一个邮件地址发送太多邮件。' not in e.error:
             raise e
 
 


### PR DESCRIPTION
之前代码中有参考 JS SDK 调用了 _logout_with_all，这个方法是 JS SDK 在客户端的时候，登出的时候顺便把 Facebook 的 SDK 也登出掉。Python SDK 中没有类似设施，因此删除掉了。