### PR TITLE
Fix: off-by-one random generation erro in hex_octet #109

### DIFF
--- a/leancloud/file_.py
+++ b/leancloud/file_.py
@@ -133,7 +133,7 @@ class File(object):
             base64.encode(self._source, output)
             self._source.seek(0)
             output.seek(0)
-            hex_octet = lambda: hex(int(0x10000 * (1 + random.random())))[2:]
+            hex_octet = lambda: hex(int(0x10000 * (1 + random.random())))[-4:]
             key = ''.join(hex_octet() for _ in xrange(4))
             key = '{0}.{1}'.format(key, self.extension)
             data = {

--- a/leancloud/file_.py
+++ b/leancloud/file_.py
@@ -133,7 +133,7 @@ class File(object):
             base64.encode(self._source, output)
             self._source.seek(0)
             output.seek(0)
-            hex_octet = lambda: hex(int(1 + random.random() * 0x10000))[2:]
+            hex_octet = lambda: hex(int(0x10000 * (1 + random.random())))[2:]
             key = ''.join(hex_octet() for _ in xrange(4))
             key = '{0}.{1}'.format(key, self.extension)
             data = {


### PR DESCRIPTION
The original hex_octet has probability 6% of generating
octet less-than-4 characters, which is not well-formed
to use in file key.

@see comments on #109.