### PR TITLE
fix bug: Query是，排序参数order参数格式错误： 应该为以,分割的字符串，而不是一个列表

### DIFF
--- a/leancloud/query.py
+++ b/leancloud/query.py
@@ -128,7 +128,7 @@ class Query(object):
         if self._skip > 0:
             params['skip'] = self._skip
         if self._order:
-            params['order'] = self._order
+            params['order'] = ",".join(self._order)
         params.update(self._extra)
         return params
 


### PR DESCRIPTION
查询时，order参数格式错了， 传了一个列表，导致多个列排序时，总是只有一个起作用。
通过和javascript sdk 对比，   才发现是python-sdk 里写错了。


