### PR TITLE
fix: don't set user._session_token to None when not set the session

### DIFF
--- a/leancloud/user.py
+++ b/leancloud/user.py
@@ -24,7 +24,8 @@ class User(Object):
         return self._session_token
 
     def _merge_magic_field(self, attrs):
-        self._session_token = attrs.get('sessionToken')
+        if 'sessionToken' in attrs:
+            self._session_token = attrs.get('sessionToken')
         attrs.pop('sessionToken', None)
 
         return super(User, self)._merge_magic_field(attrs)


### PR DESCRIPTION
User#set 的时候会将原有 session token 覆盖掉，之前的单元测试没有覆盖到不使用 master key 的情况，没有发现。