### PR TITLE
Fix engine.define decorator that made decorated function uncallable

### DIFF
--- a/leancloud/engine/leanengine.py
+++ b/leancloud/engine/leanengine.py
@@ -147,6 +147,7 @@ def register_cloud_func(func):
     if func_name in _cloud_codes:
         raise RuntimeError('cloud function: {0} is already registered'.format(func_name))
     _cloud_codes[func_name] = func
+    return func
 
 
 def dispatch_cloud_func(func_name, params):


### PR DESCRIPTION
Add a return statement that returns the original func instead of returning None.