### PR TITLE
fix: can't install in leanengine

### DIFF
--- a/leancloud/__init__.py
+++ b/leancloud/__init__.py
@@ -40,7 +40,7 @@ from .user import User
 
 
 __author__ = 'asaka <lan@leancloud.rocks>'
-__version__ = '1.4.2'
+__version__ = '1.4.3'
 
 
 __all__ = [

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,12 @@
 from setuptools import setup, find_packages
 from os import path
 
-import leancloud
-
 
 here = path.abspath(path.dirname(__file__))
 
 setup(
     name='leancloud-sdk',
-    version=leancloud.__version__,
+    version='1.4.3',
     description='LeanCloud Python SDK',
 
     url='https://leancloud.cn/',


### PR DESCRIPTION
怀疑在低版本 pip 下目前的 setup.py 中依赖 leancloud 会出现依赖问题，紧急发布一个版本改回以前的 setup.py 格式。

报错信息：
```
4/26/2016, 6:32:55 PM [ERROR] 部署失败：Requirement already satisfied (use --upgrade to upgrade): gevent>=1.0.2 in /usr/local/lib/python2.7/dist-packages (from -r requirements.txt (line 1))
Requirement already satisfied (use --upgrade to upgrade): gevent-websocket>=0.9.5 in /usr/local/lib/python2.7/dist-packages (from -r requirements.txt (line 2))
Downloading/unpacking leancloud-sdk>=1.4.2 (from -r requirements.txt (line 3))
  Downloading leancloud-sdk-1.4.2.tar.gz
  Running setup.py (path:/tmp/pip_build_root/leancloud-sdk/setup.py) egg_info for package leancloud-sdk
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/tmp/pip_build_root/leancloud-sdk/setup.py", line 4, in <module>
        import leancloud
      File "/tmp/pip_build_root/leancloud-sdk/leancloud/__init__.py", line 18, in <module>
        from . import client
      File "/tmp/pip_build_root/leancloud-sdk/leancloud/client.py", line 14, in <module>
        from leancloud import utils
      File "/tmp/pip_build_root/leancloud-sdk/leancloud/utils.py", line 14, in <module>
        import arrow
    ImportError: No module named arrow
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip_build_root/leancloud-sdk/setup.py", line 4, in <module>

    import leancloud

  File "/tmp/pip_build_root/leancloud-sdk/leancloud/__init__.py", line 18, in <module>

    from . import client

  File "/tmp/pip_build_root/leancloud-sdk/leancloud/client.py", line 14, in <module>

    from leancloud import utils

  File "/tmp/pip_build_root/leancloud-sdk/leancloud/utils.py", line 14, in <module>

    import arrow

ImportError: No module named arrow

----------------------------------------
Cleaning up...
```