### PR TITLE
feat: add leancloud.cloudfunc.get_server_time

### DIFF
--- a/leancloud/cloudfunc.py
+++ b/leancloud/cloudfunc.py
@@ -167,3 +167,7 @@ def verify_captcha(code, token):
     }
     response = leancloud.client.post('/verifyCaptcha', params)
     return response.json()['validate_token']
+
+
+def get_server_time():
+    return leancloud.client.get_server_time()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 
 import os
 import json
-import datetime
 
 from werkzeug.wrappers import Request  # type: ignore
 from wsgi_intercept import requests_intercept, add_wsgi_intercept  # type: ignore
@@ -34,7 +33,3 @@ def test_use_master_key(): # type: () -> None
     assert client.USE_MASTER_KEY is True
     leancloud.use_master_key(False)
     assert client.USE_MASTER_KEY is False
-
-
-def test_get_server_time(): # type: () -> None
-    assert type(client.get_server_time()) == datetime.datetime

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -9,6 +9,7 @@ import time
 import json
 import requests
 import typing
+from datetime import datetime
 
 import six
 from nose.tools import assert_equal
@@ -470,6 +471,10 @@ def test_request_sms_code(): # type: () -> None
             pass
         else:
             raise e
+
+
+def test_get_server_time():  # type: () -> None
+    assert type(leancloud.client.get_server_time()) == datetime
 
 
 def test_captcha():  # type: () -> None


### PR DESCRIPTION
之前放在了 leancloud.client 模块下，现在和其他 SDK 统一，放在 leancloud.cloudfunc 模块下。