### PR TITLE
:arrow_up: pin six module version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
     install_requires=install_requires,
     extras_require={
         'dev': ['sphinx', 'sphinx_rtd_theme'],
-        'test': ['nose', 'wsgi_intercept', 'flask', 'six'],
+        'test': ['nose', 'wsgi_intercept', 'flask', 'six>=1.9.0'],
     }
 )


### PR DESCRIPTION
现在代码依赖 six 1.9.0 中增加的 `python_2_unicode_comaptible` 函数。