### PR TITLE
Update message.py

### DIFF
--- a/leancloud/message.py
+++ b/leancloud/message.py
@@ -64,9 +64,9 @@ class Message(object):
         if reversed is not None:
             query_params['reversed'] = reversed
         if isinstance(before_time, datetime):
-            query_params['max_ts'] = before_time.timestamp() * 1000
+            query_params['max_ts'] = round(before_time.timestamp() * 1000)
         elif isinstance(before_time, six.integer_types) or isinstance(before_time, float):
-            query_params['max_ts'] = before_time * 1000
+            query_params['max_ts'] = round(before_time * 1000)
         if before_message_id is not None:
             query_params['msgid'] = before_message_id
         return list(cls._find(query_params))
@@ -87,9 +87,9 @@ class Message(object):
         if limit is not None:
             query_params['limit'] = limit
         if isinstance(before_time, datetime):
-            query_params['max_ts'] = before_time.timestamp() * 1000
+            query_params['max_ts'] =  round(before_time.timestamp() * 1000)
         elif isinstance(before_time, six.integer_types) or isinstance(before_time, float):
-            query_params['max_ts'] = before_time * 1000
+            query_params['max_ts'] = round(before_time * 1000)
         if before_message_id is not None:
             query_params['msgid'] = before_message_id
         return list(cls._find(query_params))
@@ -108,9 +108,9 @@ class Message(object):
         if limit is not None:
             query_params['limit'] = limit
         if isinstance(before_time, datetime):
-            query_params['max_ts'] = before_time.timestamp() * 1000
+            query_params['max_ts'] = round(before_time.timestamp() * 1000)
         elif isinstance(before_time, six.integer_types) or isinstance(before_time, float):
-            query_params['max_ts'] = before_time * 1000
+            query_params['max_ts'] = round(before_time * 1000)
         if before_message_id is not None:
             query_params['msgid'] = before_message_id
         return list(cls._find(query_params))


### PR DESCRIPTION
因为timestamp() 获取到的float值*1000以后还是浮点数，而api 接受的值是整型，导致api调用失败，需要取整处理以后交给api
>>> dt = datetime.datetime(2018,10,15)
>>> dt.timestamp() * 1000
1539532800000.0
>>>

修改后，执行ok
>>> messages = message.find_by_conversation(conversation_id,limit,True,dt)
DEBUG:urllib3.connectionpool:Resetting dropped connection: x5auvr7e.api.lncld.net
DEBUG:urllib3.connectionpool:https://x5auvr7e.api.lncld.net:443 "GET /1.1/rtm/messages/history?reversed=True&limit=10&convid=5bc304ad60d9007f7ba79091&max_ts=1539532800000 HTTP/1.1" 200 None
>>> 
>>> 