### PR TITLE
fix(LeanObject): test existence more accurately

### DIFF
--- a/leancloud/object_.py
+++ b/leancloud/object_.py
@@ -517,12 +517,21 @@ class Object(six.with_metaclass(ObjectMeta, object)):
         """
         判断当前对象是否已经保存至服务器。
 
+        该方法为 SDK 内部使用（save 调用此方法 dispatch 保存操作为 REST API 的 POST 和 PUT 请求）。
+        查询对象是否在服务器上存在请使用 is_existed 方法。
+
+
         :rtype: bool
         """
         return False if self.id else True
 
     def is_existed(self):
-        return bool(self.id)
+        """
+        判断当前对象是否在服务器上已经存在。
+
+        :rtype: bool
+        """
+        return self.has("createdAt")
 
     def get_acl(self):
         """

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -237,7 +237,9 @@ def test_fetch(): # type: () -> None
     album.save()
 
     album_1 = Album.create_without_data(album.id)
+    assert album_1.is_existed() is False
     album_1.fetch(include=['parent'], select=['name', 'parent'])
+    assert album_1.is_existed() is True
     assert album_1.get('parent').get('name') == 'Nightwish'
     assert not album_1.has('title')
 
@@ -250,6 +252,11 @@ def test_has(): # type: () -> None
     album.set('foo', 'bar')
     assert album.has('foo') is True
     assert album.has('bar') is False
+
+
+def test_existence(): # type: () -> None
+    album = Album()
+    assert album.is_existed() is False
 
 
 def test_get_set_acl(): # type: () -> None

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -169,6 +169,9 @@ def test_basic_query(): # type: () -> None
     # get
     GameScore.query.get(game_score.id)
 
+    # get nonexist
+    assert GameScore.query.get("NonexistentID").is_existed() is False
+
     # count
     eq_(GameScore.query.count(), 10)
 


### PR DESCRIPTION
Previously, the code checks whether the object has an truthy objectId,
to determine the existence of a LeanCloud object.
But if the object is constructed via `query.get("nonexist_objectId")`,
then it does have an objectId (`{"objectId": "nonexist_objectId"}`).
Therefore, we check whether the object has the `createdAt` attribute
instead.