### PR TITLE
fix(LeanEngine): X-LC-Prod request header

### DIFF
--- a/leancloud/client.py
+++ b/leancloud/client.py
@@ -25,7 +25,16 @@ APP_ID = None
 APP_KEY = None
 MASTER_KEY = None
 HOOK_KEY = None
-USE_PRODUCTION = '1'
+if os.getenv('LEANCLOUD_APP_ENV') == 'production':
+    USE_PRODUCTION = '1'
+elif os.getenv('LEANCLOUD_APP_ENV') == 'stage':
+    USE_PRODUCTION = '0'
+else:  # probably on local machine
+    if os.getenv('LEAN_CLI_HAVE_STAGING') == 'true':
+        USE_PRODUCTION = '0'
+    else:  # free trial instance only
+        USE_PRODUCTION = '1'
+
 USE_HTTPS = True
 # 兼容老版本，如果 USE_MASTER_KEY 为 None ，并且 MASTER_KEY 不为 None，则使用 MASTER_KEY
 # 否则依据 USE_MASTER_KEY 来决定是否使用 MASTER_KEY


### PR DESCRIPTION
修正了云引擎预备环境错误触发生产环境 hook 的问题（之前 python-sdk 并不尊重运行实例的环境变量）。
为了保证向后兼容性（保证 `use_production` 可用），
所以仍然保留了使用全局变量控制 X-LC-Prod 头这样不太干净的方式。
相应地，也没有写新测试（因为 python 重新加载模块并不会更新对旧值的引用，使用 `del sys.modules` 这样 hacky 的方式会让测试很难看，也很容易造成其他测试的依赖问题）。

等以后 Python 发下一个大版本的时候再引入不用全局变量的方式。