### PR TITLE
docs(readme): update outdated install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ LeanCloud Python SDK
 ## Install
 
 ```bash
-pip install leancloud-sdk
+pip install leancloud
 ```
 
 or
 
 ```
-easy_install leancloud-sdk
+easy_install leancloud
 ```
 
 Maybe you need the `sudo` prefix depends on your OS environment.


### PR DESCRIPTION
The package name has changed from leancloud-sdk
to leancloud long long ago.

Thanks to Tim Du for reporting this issue
(ticket: 20659)