### PR TITLE
fix: typo in get para: deafult -> default

### DIFF
--- a/leancloud/object_.py
+++ b/leancloud/object_.py
@@ -342,7 +342,7 @@ class Object(six.with_metaclass(ObjectMeta, object)):
             raise TypeError('acl must be a ACL')
         return True
 
-    def get(self, attr, deafult=None):
+    def get(self, attr, default=None, deafult=None):
         """
         获取对象字段的值
 
@@ -350,7 +350,10 @@ class Object(six.with_metaclass(ObjectMeta, object)):
         :type attr: string_types
         :return: 字段值
         """
-        return self._attributes.get(attr, deafult)
+        # for backward compatibility
+        if (deafult is not None) and (default is None):
+            default = deafult
+        return self._attributes.get(attr, default)
 
     def relation(self, attr):
         """

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -96,9 +96,15 @@ def test_get(): # type: () -> None
     assert album.get('foo') == 'bar'
 
 
-def test_get_deafult(): # type: () -> None
+def test_get_default(): # type: () -> None
     album = Album()
     assert album.get('foo', 'bar') == 'bar'
+    assert album.get('foo', default='bar') == 'bar'
+    # for backward compatibility
+    assert album.get('foo', deafult='bar') == 'bar'
+    assert album.get('foo', 'bar', deafult='foobar') == 'bar'
+    assert album.get('foo', deafult='foobar', default='bar') == 'bar'
+
 
 
 def test_unset(): # type: () -> None


### PR DESCRIPTION
This commit maintains compatibility with existing code
using the mistyped `deafult` parameter.

close #417