### PR TITLE
fix: conditional dependencies for Python 2

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 
@@ -39,7 +39,7 @@ jobs:
         flake8 . --count --exit-zero --statistics
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Maybe you need the `sudo` prefix depends on your OS environment.
 
 ## Supported Python Versions
 
-Python 2.7 and Python 3.6+.
+Python 2.7.18 and Python 3.6+.
 
 ## Generate API document
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests>=2.25.1
 Werkzeug>=0.16.0,<=2.0.0
 secure-cookie>=0.1.0,<1.0.0
 gevent>=21.1.0,<22.0.0
+typing; python_version < '3.5'

--- a/setup.py
+++ b/setup.py
@@ -6,26 +6,17 @@ import sys
 here = path.abspath(path.dirname(__file__))
 
 install_requires = [
+    "arrow>=0.17.0,<1.0.0; python_version < '3.6'",
+    "arrow>=1.0.0,<2.0.0; python_version >= '3.6'",
     'iso8601>=0.1.14',
     'six>=1.11.0',
     'qiniu>=7.1.4,<7.2.4',
     'requests>=2.25.1',
     'Werkzeug>=0.16.0,<=2.0.0',
     'secure-cookie>=0.1.0,<1.0.0',
-    'gevent>=21.1.0,<22.0.0'
+    'gevent>=21.1.0,<22.0.0',
+    "typing; python_version < '3.5'"
 ]
-
-if sys.version_info < (3, 6, 0):
-    install_requires.append('arrow>=0.17.0,<1.0.0')
-else:
-    install_requires.append('arrow>=1.0.0,<2.0.0')
-
-if sys.version_info < (3, 5, 0):
-    install_requires.append('typing')
-
-if sys.version_info < (2, 7, 9):
-    install_requires.append('pyOpenSSL')
-    install_requires.append('idna')
 
 setup(
     name='leancloud',


### PR DESCRIPTION
Since pip install wheels will not execute arbitrary code,
we need to specify the conditional dependencies statically.

related ticket: 37431

Other changes:

- Only support Python 2.7.18 for Python 2.
- Use ubuntu 20.04 for github actions.
