### PR TITLE
fix: on_auth_data hook

### DIFF
--- a/leancloud/engine/leanengine.py
+++ b/leancloud/engine/leanengine.py
@@ -517,7 +517,7 @@ def dispatch_on_login(_cloud_codes, app_params, params):
     return func(user)
 
 def register_on_auth_data(_cloud_codes, func):
-    func_name = "__on_auth_data__User"
+    func_name = "__on_authdata__User"
 
     if func_name in _cloud_codes:
         raise RuntimeError("on authdata is already registered")
@@ -529,7 +529,7 @@ def dispatch_on_auth_data(_cloud_codes, app_params, params):
     if not current_hook_key or current_hook_key != HOOK_KEY:
         raise LeanEngineError(code=401, message="Unauthorized.")
 
-    func = _cloud_codes.get("__on_auth_data__User")
+    func = _cloud_codes.get("__on_authdata__User")
     if not func:
         return
 

--- a/leancloud/engine/leanengine.py
+++ b/leancloud/engine/leanengine.py
@@ -533,7 +533,7 @@ def dispatch_on_auth_data(_cloud_codes, app_params, params):
     if not func:
         return
 
-    auth_data = params["object"]
+    auth_data = params["authData"]
     return func(auth_data)
     
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -509,7 +509,7 @@ def test_on_auth_data():  # type: () -> None
 
     response = requests.post(
         url + "/__engine/1.1/functions/_User/onAuthData",
-        json={"object": {
+        json={"authData": {
             "foo": {
                 "openid": "openid",
                 "access_token": "access_token",


### PR DESCRIPTION
The key LeanEngine received is not `object` but `authData`.
Thank @cshuaimin for bringing this to our attention.