### PR TITLE
fix connection reset error

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ six = ">=1.11.0"
 qiniu = ">=7.1.4,<7.2.4"
 "urllib3" = ">=1.24.3,<=1.25.3"
 requests = ">=2.20.0,<=2.22.0"
+requests-toolbelt = ">=1.0.0"
 Werkzeug = ">=0.11.11,<1.0.0"
 gevent = ">=22.10.2,<23.0.0"
 typing = { version = "*", markers = "python_version < '3.5.0'" }

--- a/leancloud/client.py
+++ b/leancloud/client.py
@@ -13,6 +13,7 @@ import functools
 
 import six
 import requests
+from requests_toolbelt.adapters.socket_options import TCPKeepAliveAdapter
 
 import leancloud
 from leancloud import utils
@@ -43,6 +44,8 @@ REGION = "CN"
 
 app_router = None
 session = requests.Session()
+session.mount("http://", TCPKeepAliveAdapter())
+session.mount("https://", TCPKeepAliveAdapter())
 request_hooks = {}
 
 SERVER_VERSION = "1.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ iso8601>=0.1.14
 six>=1.11.0
 qiniu>=7.3.1
 requests>=2.25.1
+requests-toolbelt>=1.0.0
 Werkzeug>=0.16.0,<2.0.0
 secure-cookie>=0.1.0,<1.0.0
 gevent>=22.10.2,<23.0.0

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ install_requires = [
     'six>=1.11.0',
     'qiniu==7.3.1',
     'requests>=2.25.1',
+    'requests-toolbelt>=1.0.0',
     'Werkzeug>=0.16.0,<2.0.0',
     'secure-cookie>=0.1.0,<1.0.0',
     'gevent>=22.10.2,<23.0.0',


### PR DESCRIPTION
Enable TCP keepalive socket option when requesting to storage.
Fix "ConnectionResetError: [Errno 104] Connection reset by peer"
ticket #41769

https://github.com/psf/requests/issues/4664

https://codearcana.com/posts/2015/08/28/tcp-keepalive-is-a-lie.html
https://blog.cloudflare.com/when-tcp-sockets-refuse-to-die